### PR TITLE
Add --help and --version command-line options

### DIFF
--- a/GDialog/CommandLineOptions.cs
+++ b/GDialog/CommandLineOptions.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+
+namespace GDialog;
+
+/// <summary>
+/// Handles command-line option processing and display.
+/// </summary>
+internal static class CommandLineOptions
+{
+    /// <summary>
+    /// Shows usage information when no arguments are provided.
+    /// </summary>
+    /// <returns>Exit code 2 (invalid usage).</returns>
+    public static int ShowUsage()
+    {
+        Console.WriteLine("Usage: gdialog <script.gds>");
+        Console.WriteLine("Try 'gdialog --help' for more information.");
+        return 2;
+    }
+
+    /// <summary>
+    /// Shows help information with usage, options, and examples.
+    /// </summary>
+    /// <returns>Exit code 0 (success).</returns>
+    public static int ShowHelp()
+    {
+        Console.WriteLine("gdialog - Game Dialog Script Interpreter");
+        Console.WriteLine();
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  gdialog <script.gds>          Execute a Game Dialog Script file");
+        Console.WriteLine("  gdialog --help                Show this help message");
+        Console.WriteLine("  gdialog --version             Show version information");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  -h, --help                    Display this help message and exit");
+        Console.WriteLine("  -v, --version                 Display version information and exit");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  gdialog greeting.gds          Run the greeting.gds script");
+        Console.WriteLine("  gdialog demo.gds              Run the demo.gds script");
+        Console.WriteLine();
+        Console.WriteLine("For more information, visit: https://github.com/bitpatch/game-dialog-cli");
+        return 0;
+    }
+
+    /// <summary>
+    /// Shows version information.
+    /// </summary>
+    /// <returns>Exit code 0 (success).</returns>
+    public static int ShowVersion()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        var versionString = version != null 
+            ? $"{version.Major}.{version.Minor}.{version.Build}" 
+            : "unknown";
+        Console.WriteLine($"gdialog version {versionString}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Shows error message for unknown options.
+    /// </summary>
+    /// <param name="option">The unknown option that was provided.</param>
+    /// <returns>Exit code 2 (invalid usage).</returns>
+    public static int ShowUnknownOption(string option)
+    {
+        Console.WriteLine($"Error: Unknown option '{option}'");
+        Console.WriteLine("Use 'gdialog --help' for usage information.");
+        return 2;
+    }
+}

--- a/GDialog/Program.cs
+++ b/GDialog/Program.cs
@@ -1,100 +1,16 @@
-﻿using System.Linq;
-using System.Text;
-using BitPatch.DialogLang;
+﻿using GDialog;
 
+// Handle command-line options and script execution
 if (args.Length == 0)
 {
-    Console.WriteLine("Usage: dialog <script.gds>");
-    return 1;
+    return CommandLineOptions.ShowUsage();
 }
 
-string scriptPath = args[0];
-
-if (!File.Exists(scriptPath))
+return args[0] switch
 {
-    Console.WriteLine($"Error: File '{scriptPath}' not found.");
-    return 1;
-}
-
-try
-{
-    var dialog = new Dialog();
-
-    // Use streaming from file - no need to load entire file into memory
-    using var fileStream = File.OpenRead(scriptPath);
-    using var reader = new StreamReader(fileStream);
-
-    foreach (var output in dialog.Execute(reader))
-    {
-        Console.WriteLine(output);
-    }
-
-    Console.WriteLine("\nVariables:");
-    foreach (var (name, value) in dialog.Variables)
-    {
-        Console.WriteLine($"  {name} = {value}");
-    }
-
-    return 0;
-}
-catch (ScriptException ex)
-{
-    Console.WriteLine($"{ex.Message}, line {ex.Line}");
-    PrintScriptError(scriptPath, ex.Line, ex.Initial, ex.Final);
-    return 1;
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"Error: {ex.Message}");
-    return 1;
-}
-
-static void PrintScriptError(string scriptPath, int line, int startColumn, int endColumn)
-{
-    try
-    {
-        if (line <= 0)
-        {
-            Console.WriteLine("    <unknown location>");
-            return;
-        }
-
-        string? errorLine = File.ReadLines(scriptPath).Skip(line - 1).FirstOrDefault();
-        if (errorLine == null)
-        {
-            Console.WriteLine("    <line unavailable>");
-            return;
-        }
-
-        string prefix = "    ";
-        Console.WriteLine(prefix + errorLine);
-
-        // Build the underline with proper spacing and tabs
-        var underlineBuilder = new StringBuilder();
-        underlineBuilder.Append(' ', prefix.Length);
-        
-        // Add spaces/tabs up to the start column
-        for (int i = 1; i < startColumn; i++)
-        {
-            if (i <= errorLine.Length && errorLine[i - 1] == '\t')
-            {
-                underlineBuilder.Append('\t');
-            }
-            else
-            {
-                underlineBuilder.Append(' ');
-            }
-        }
-
-        // Underline the error range with tildes
-        int underlineLength = Math.Max(1, endColumn - startColumn);
-        underlineBuilder.Append('~', underlineLength);
-        
-        Console.WriteLine(underlineBuilder.ToString());
-    }
-    catch (Exception)
-    {
-        Console.WriteLine("    <unable to display error location>");
-    }
-}
+    "--help" or "-h" => CommandLineOptions.ShowHelp(),
+    "--version" or "-v" => CommandLineOptions.ShowVersion(),
+    string arg when arg.StartsWith('-') => CommandLineOptions.ShowUnknownOption(arg),
+    _ => ScriptExecutor.Execute(args[0])
+};
 

--- a/GDialog/ScriptExecutor.cs
+++ b/GDialog/ScriptExecutor.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using BitPatch.DialogLang;
+
+namespace GDialog;
+
+/// <summary>
+/// Handles execution of Game Dialog Script files.
+/// </summary>
+internal static class ScriptExecutor
+{
+    /// <summary>
+    /// Executes a Game Dialog Script file.
+    /// </summary>
+    /// <param name="scriptPath">Path to the script file to execute.</param>
+    /// <returns>Exit code: 0 for success, 1 for errors.</returns>
+    public static int Execute(string scriptPath)
+    {
+        if (!File.Exists(scriptPath))
+        {
+            Console.WriteLine($"Error: File '{scriptPath}' not found.");
+            return 1;
+        }
+
+        try
+        {
+            var dialog = new Dialog();
+
+            // Use streaming from file - no need to load entire file into memory
+            using var fileStream = File.OpenRead(scriptPath);
+            using var reader = new StreamReader(fileStream);
+
+            foreach (var output in dialog.Execute(reader))
+            {
+                Console.WriteLine(output);
+            }
+
+            Console.WriteLine("\nVariables:");
+            foreach (var (name, value) in dialog.Variables)
+            {
+                Console.WriteLine($"  {name} = {value}");
+            }
+
+            return 0;
+        }
+        catch (ScriptException ex)
+        {
+            Console.WriteLine($"{ex.Message}, line {ex.Line}");
+            PrintScriptError(scriptPath, ex.Line, ex.Initial, ex.Final);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    /// <summary>
+    /// Prints a script error with context from the source file.
+    /// </summary>
+    /// <param name="scriptPath">Path to the script file.</param>
+    /// <param name="line">Line number where the error occurred.</param>
+    /// <param name="startColumn">Starting column of the error.</param>
+    /// <param name="endColumn">Ending column of the error.</param>
+    private static void PrintScriptError(string scriptPath, int line, int startColumn, int endColumn)
+    {
+        try
+        {
+            if (line <= 0)
+            {
+                Console.WriteLine("    <unknown location>");
+                return;
+            }
+
+            string? errorLine = File.ReadLines(scriptPath).Skip(line - 1).FirstOrDefault();
+            if (errorLine == null)
+            {
+                Console.WriteLine("    <line unavailable>");
+                return;
+            }
+
+            string prefix = "    ";
+            Console.WriteLine(prefix + errorLine);
+
+            // Build the underline with proper spacing and tabs
+            var underlineBuilder = new StringBuilder();
+            underlineBuilder.Append(' ', prefix.Length);
+            
+            // Add spaces/tabs up to the start column
+            for (int i = 1; i < startColumn; i++)
+            {
+                if (i <= errorLine.Length && errorLine[i - 1] == '\t')
+                {
+                    underlineBuilder.Append('\t');
+                }
+                else
+                {
+                    underlineBuilder.Append(' ');
+                }
+            }
+
+            // Underline the error range with tildes
+            int underlineLength = Math.Max(1, endColumn - startColumn);
+            underlineBuilder.Append('~', underlineLength);
+            
+            Console.WriteLine(underlineBuilder.ToString());
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("    <unable to display error location>");
+        }
+    }
+}


### PR DESCRIPTION
- Implement --help/-h to display usage information
- Implement --version/-v to show version number
- Add proper exit codes (0 for success, 1 for script errors, 2 for CLI errors)
- Fix usage message: 'dialog' → 'gdialog'
- Refactor code into CommandLineOptions and ScriptExecutor classes